### PR TITLE
Fixes #1: check if 'bs' is running before running 'hcd'.

### DIFF
--- a/bin/hcd-agent
+++ b/bin/hcd-agent
@@ -6,6 +6,10 @@
 export HCLOG_GOSSIP_ENABLE=true
 #export HC_DEFAULT_ENABLEMDNS=true
 
+# @TODO make these variables acceible across the toolkit
+HCTOOLS_BS_SERVER="127.0.0.1"
+HCTOOLS_BS_PORT="5001"
+
 holochain_agents_path=$HOME/.holochain-agents
 agent_name=$1
 
@@ -17,6 +21,18 @@ if [ -z $agent_name ] || [ ! -d $holochain_agents_path/$agent_name ]; then
 	cd $holochain_agents_path
 	ls -d ./*/ | cut -f2 -d'/' | awk '$0=" └─ "$0'
 	exit
+fi
+
+port_is_closed=$(timeout 2 bash -c "</dev/tcp/$HCTOOLS_BS_SERVER/$HCTOOLS_BS_PORT"; echo $?)
+if [ ! -z port_is_closed ]; then
+	echo ""
+	echo "[WARNING] Bootstrap Server is NOT running on $HCTOOLS_BS_SERVER:$HCTOOLS_BS_PORT";
+	echo ""
+	echo "You can run it by:"
+	echo "bs --port=$HCTOOLS_BS_PORT"
+	echo ""
+	echo "Trying to run hcd regardless..."
+	echo ""
 fi
 
 hcd --debug --verbose --path $holochain_agents_path/$agent_name ${*:2}


### PR DESCRIPTION
@TODO define HCTOOLS_BS_PORT and HCTOOLS_BS_SERVER as standard variable across all the toolkit.